### PR TITLE
代表的な誤用例を追加

### DIFF
--- a/dict/prh.yml
+++ b/dict/prh.yml
@@ -15,3 +15,114 @@ rules:
   # 「例外を補足」
   - expected: 例外を捕捉
     patterns: 例外を補足
+  - expected: 愛くるしい
+    patterns: 愛苦しい
+    prh: http://dictionary.goo.ne.jp/jn/692/meaning/m0u/
+  - expected: あくどい
+    patterns: 悪どい
+    prh: https://web.archive.org/web/20150408184042/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=173
+  - expected: $1を傾ける
+    patterns: /(うんちく|薀蓄)を垂れる/
+    prh: https://gakumado.mynavi.jp/gmd/articles/27802
+  - expected: 転嫁
+    patterns: 転稼
+    prh: https://gakumado.mynavi.jp/gmd/articles/27802
+  - expected: こんにちは
+    patterns: こんにちわ
+    prh: http://japanknowledge.com/articles/blognihongo/entry.html?entryid=113
+  - expected: 愛嬌を$1まく
+    patterns: /愛想を(振り|ふり)まく/
+    prh: https://web.archive.org/web/20150408182846/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=115
+  - expected: 論陣を張る
+    patterns: 論戦を張る
+    prh: https://web.archive.org/web/20150407172247/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=119
+  - expected: 潔い
+    patterns: /(いさぎ良い|潔よい)/
+    prh: https://web.archive.org/web/20150407155736/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=169
+  - expected: 寸暇を惜しんで
+    patterns: 寸暇を惜しまず
+    prh: https://web.archive.org/web/20150408185444/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=132
+  - expected: 間を置かず
+    patterns: 寸暇を置かず
+    prh: https://web.archive.org/web/20150407185011/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=133
+  - expected: 二つ返事
+    patterns: 一つ返事
+    prh: https://web.archive.org/web/20150408185551/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=131
+  - expected: 怒り心頭に発する
+    patterns: 怒り心頭に達する
+    prh: https://web.archive.org/web/20150408185212/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=188
+  - expected: 熱に浮かされる
+    patterns: 熱にうなされる
+    prh: https://web.archive.org/web/20150407160525/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=48
+  - expected: やるせぬ
+    patterns: やるせない
+    prh: https://web.archive.org/web/20150408185109/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=203
+  - expected: 馬脚を露わす
+    patterns: /馬脚を(晒す|さらす|出す)/
+    prh: https://web.archive.org/web/20150407184513/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=209
+  - expected: 雪辱を果たす
+    patterns: 雪辱を晴らす
+    prh: https://web.archive.org/web/20150407155513/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=212
+  - expected: うろ覚え
+    patterns: うる覚え
+    prh: https://web.archive.org/web/20150407161100/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=216
+  - expected: 首を$1
+    patterns: /頭を(傾げる|かしげる|かたげる)/
+    prh: https://web.archive.org/web/20150408190425/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=213
+  - expected: 舌先三寸
+    patterns: 口先三寸
+    prh: https://web.archive.org/web/20140517134132/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=224
+  - expected: 舌の根の乾かぬ
+    patterns: 舌の先の乾かぬ
+    prh: https://web.archive.org/web/20150408184454/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=226
+  - expected: 悪評高い
+    patterns: /悪評(?:嘖々|嘖嘖|さくさく)/
+    prh: https://www.nhk.or.jp/bunken/summary/kotoba/gimon/128.html
+  - expected: 器官
+    patterns: 器管
+    prh: https://web.archive.org/web/20140726094700/https://japanknowledge.com/articles/blognihongo/entry.html?entryid=235
+  - expected: $1を切る
+    patterns: /(火蓋|火ぶた)を(?:切って)?落とす/
+    prh: http://japanknowledge.com/articles/blognihongo/entry.html?entryid=314
+  - expected: $1が切られる
+    patterns: /(火蓋|火ぶた)が(?:切って)?落とされる/
+    prh: https://www.nhk.or.jp/bunken/summary/kotoba/gimon/137.html
+  - expected: $1島$2$3
+    patterns: /(取り付く|とりつく)(?:暇|ヒマ|ひま)(も|が)(?:無い|ない)/
+    prh: https://web.archive.org/web/20150206044421/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=264
+  - expected: 上を下への
+    patterns: /上(?:や|へ)下への/
+    prh: https://web.archive.org/web/20150417042551/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=274
+  - expected: 押しも押されもせぬ
+    patterns: 押しも押されぬ
+    prh: https://web.archive.org/web/20150710180524/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=286
+  - expected: 全て
+    patterns: /すべからく(?!.*べ[しき])/
+    prh: https://web.archive.org/web/20150825091657/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=293
+  - expected: 書き入れ
+    patterns: 掻き入れ
+    prh: http://japanknowledge.com/articles/blognihongo/entry.html?entryid=309
+  - expected: 引くに引けない
+    patterns: 引くに引かれない
+    prh: https://www.nhk.or.jp/bunken/summary/kotoba/uraomote/110.html
+  - expected: 死ぬに死ねない
+    patterns: 死ぬに死なれない
+    prh: https://www.nhk.or.jp/bunken/summary/kotoba/uraomote/110.html
+  - expected: 腸が煮えくり返る
+    patterns: 腹が煮えくり返る
+    prh: https://www.nhk.or.jp/bunken/summary/kotoba/uraomote/110.html
+  - expected: 胸三寸
+    patterns: 胸先三寸
+    prh: https://www.nhk.or.jp/bunken/summary/kotoba/uraomote/110.html
+  - expected: 腹に据えかねる
+    patterns: 肝に据えかねる
+    prh: https://www.nhk.or.jp/bunken/summary/kotoba/uraomote/110.html
+  - expected: 鼻も引っ掛けない
+    patterns: /鼻にも(?:かけない|掛けない)/
+    prh: https://www.nhk.or.jp/bunken/summary/kotoba/uraomote/110.html
+  - expected: 腹を抱えて
+    patterns: へそを抱えて
+    prh: https://www.nhk.or.jp/bunken/summary/kotoba/uraomote/110.html
+  - expected: 後ろ盾
+    patterns: 後ろ立て
+    prh: http://woman.mynavi.jp/article/140212-30/


### PR DESCRIPTION
日本語に関するルールということもあり日本語にて PR を送らさせていただきます．

README には「技術文書をターゲットとする」などの対象を限定する記述がなかったため，一般に「誤用」と考えられている表現を多く追加してみました．
もしパッケージを分けたほうがよいということであれば，この PR は取り下げます．
## 誤用例の蒐集元

誤用例は主に[日国などを執筆されている方が書かれた Japan Knowledge のコラム「日本語どうでしょう？」](http://japanknowledge.com/articles/blognihongo/archive.html)から蒐集しました．書籍化に伴い大部分がアーカイブ化されてしまっているため，Internet Archive へのリンクが大半になっています．

上記コラムの中で，以下のような内容については収録しませんでした．
#### 誤用であると言われていたが実際は誤用ではないと考えられているもの

| 誤用とされている表現 | 正しいとされている表現 | 出典 |
| :-: | :-: | :-: |
| 汚名挽回 | 汚名返上 | [Japan Knowledge](https://web.archive.org/web/20150408190227/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=205) |
| 的を得る | 的を射る | [Japan Knowledge](https://web.archive.org/web/20150408184831/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=8) |
#### 古くから誤用とされる表現の例があり，辞書作成者も新しい表現として認めても良いのではないかと考えているもの

| 誤用とされている表現 | 正しいとされている表現 | 出典 |
| :-: | :-: | :-: |
| 声をあららげる | 声をあらげる | [Japan Knowledge](https://web.archive.org/web/20150407162300/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=28) |
| やんごとない事情 | よんどころない事情 | [Japan Knowledge](https://web.archive.org/web/20150407162303/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=16) |
| 足元を掬われる | 足を掬われる | [Japan Knowledge](https://web.archive.org/web/20150407174513/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=202) |
| 采配を振るう | 采配を振る | [Japan Knowledge](https://web.archive.org/web/20150407161337/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=211) |
| 二の舞いを踏む | 二の舞を演じる | [Japan Knowledge](https://web.archive.org/web/20150407183720/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=248) |
| 願わくば | 願わくは | [Japan Knowledge](http://japanknowledge.com/articles/blognihongo/entry.html?entryid=323) |
#### 意味を誤って用いられることが多いもの
- [話が煮詰まる](https://web.archive.org/web/20150408184603/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=20)
- [檄を飛ばす](https://web.archive.org/web/20150408185005/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=58)
- [暮れなずむ](https://web.archive.org/web/20150408183316/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=140)

など
## その他の誤用例リストについて

[ことば（放送用語） | NHK放送文化研究所](https://www.nhk.or.jp/bunken/kotoba/index.html) にも同様のコラムがありますが，今回は割愛しました．

また，[間違えやすい日本語](http://www.h3.dion.ne.jp/~urutora/machi1.htm) にも多くの表現が載っていますが，個々の表現を誤りと見なす出典が書かれていないため対象としませんでした．
## 制限

正規表現ベースによる機械的チェックのため，
- 意味の誤用を判断することはできない (そのため「煮詰まる」のような例は入れられない)
- 語尾が活用してしまうと検出できない (「愛苦しい」という項目に対して「愛苦しかった」は検出できない)
  という問題があります．

---

以上，どうぞよろしくお願い致します．
