### PR TITLE
feat(dict): 誤用例の追加

### DIFF
--- a/dict/prh.yml
+++ b/dict/prh.yml
@@ -126,3 +126,97 @@ rules:
   - expected: 後ろ盾
     patterns: 後ろ立て
     prh: http://woman.mynavi.jp/article/140212-30/
+  - expected: 絶体絶命
+    pattern: 絶対絶命
+    prh: 参照 講談社校閲部『熟練校閲者が教える　間違えやすい日本語実例集  』講談社文庫、2018年。
+  - expected: 有頂天
+    pattern: 有頂点
+    prh: 参照 講談社校閲部『熟練校閲者が教える　間違えやすい日本語実例集  』講談社文庫、2018年。
+  - expected: 自己本位
+    pattern: /(自分本位|自[己分]本意)/
+    prh: 参照 講談社校閲部『熟練校閲者が教える　間違えやすい日本語実例集  』講談社文庫、2018年。
+  - expected: 一触即発
+    pattern: 一発即発
+  - expected: 意気揚々
+    pattern: 意気高々
+  - expected: 青息吐息
+    pattern: 青色吐息
+  - expected: 固定観念
+    pattern: 固定概念
+  - expected: 目$1留ま$2
+    pattern: /目(に|にも|が)止ま([らろりっるれ])/
+    prh: 「止」は動作の停止、「留」は意識を向ける時に使う
+  - expected: 目を留め
+    pattern: 目を止め
+    prh: 「止」は動作の停止、「留」は意識を向ける時に使う
+  - expected: 無理$1利かない
+    pattern: /無理([のが])効かない/
+    prh: 「効」は具体的な効果がある時に使う
+  - expected: 睨みを利かせ
+    pattern: 睨みを効かせ
+    prh: 「効」は具体的な効果がある時に使う
+  - expected: $1に障る
+    pattern: /([気癪])に触る/
+    prh: 部位に触れて不快に覚えることを「障」と表す
+  - expected: 見るに堪えない
+    pattern: /見るに[耐絶]えない/
+    prh: （それをする）価値があることを「堪える」という
+  - expected: 頭に入れておく
+    pattern: /頭に留め[て]?[置お]く/
+  - expected: 歓心を買う
+    pattern: /(?:関心|感心)を買う/
+  - expected: 恩に着る
+    pattern: 恩を着る
+  - expected: 脚光を浴び
+    pattern: 脚光を集め
+  - expected: 口が堅い
+    pattern: /口が[固硬]い/
+    prh: 堅実さを意味する「堅い」を用いる
+  - expected: づらい
+    pattern: ずらい
+    prh: 動詞の連用形+辛い（つらい）
+  - expected: 思い$1かない
+    pattern: /思いも([付つ])かない/
+    prh: 「思いつかない」で一つの動詞
+  - expected: たり$1ない
+    pattern: /足り([得え])ない/
+    prh: 参照 講談社校閲部『熟練校閲者が教える　間違えやすい日本語実例集  』講談社文庫、2018年。
+  - expected: 案の定
+    pattern: /案の[上条]/
+    prh: 参照 講談社校閲部『熟練校閲者が教える　間違えやすい日本語実例集  』講談社文庫、2018年。
+  - expected: 合いの手を入れる
+    pattern: 合いの手を打つ
+    prh: 参照 https://japanknowledge.com/articles/blognihongo/entry.html?entryid=221
+  - expected: 相$1を打つ
+    pattern: /相(づち|槌)を入れる/
+    prh: 参照 https://japanknowledge.com/articles/blognihongo/entry.html?entryid=221
+  - expected: 耳当たり$1$2
+    pattern: /耳障り([のが])?([良よ]い)/
+    prh: 参照 http://www.bunka.go.jp/prmagazine/rensai/kotoba/kotoba_004.html
+  - expected: 無理からぬ
+    pattern: 無理なからぬ
+    prh: 参照 神永曉『微妙におかしな日本語:ことばの結びつきの正解・不正解』草思社、2018年。
+  - expected: 間髪をいれず
+    pattern: /間髪([い容]れず|[を]?[お置]かず)/
+    prh: 参照 神永曉『微妙におかしな日本語:ことばの結びつきの正解・不正解』草思社、2018年。
+  - expected: 食指が動く
+    pattern: /食指[をが](そそる|そそられる|伸ばす)/
+    prh: 参照 神永曉『微妙におかしな日本語:ことばの結びつきの正解・不正解』草思社、2018年。
+  - expected: 念頭におく
+    pattern: /念頭に(入れる|する)/
+    prh: 参照 神永曉『微妙におかしな日本語:ことばの結びつきの正解・不正解』草思社、2018年。
+  - expected: 嫌気が差$1
+    pattern: /嫌気が(して|した)/
+    prh: 参照 神永曉『微妙におかしな日本語:ことばの結びつきの正解・不正解』草思社、2018年。
+  - expected: 精根$1尽き
+    pattern: /精魂(が)?尽き/
+    prh: 参照 神永曉『微妙におかしな日本語:ことばの結びつきの正解・不正解』草思社、2018年。
+  - expected: 苦虫を噛み潰したような
+    pattern: /苦虫を[か噛]んだような/
+    prh: 参照 神永曉『微妙におかしな日本語:ことばの結びつきの正解・不正解』草思社、2018年。
+  - expected: 活$1入れ
+    pattern: /喝(を)?入れ/
+    prh: 参照 神永曉『微妙におかしな日本語:ことばの結びつきの正解・不正解』草思社、2018年。
+  - expected: 一堂に会する
+    pattern: 一同に会する
+    prh: 参照 神永曉『微妙におかしな日本語:ことばの結びつきの正解・不正解』草思社、2018年。


### PR DESCRIPTION
個人的に収集していた誤用例35件を追加いたしました。

- 絶対絶命　⇒　絶体絶命
- 有頂点　⇒　有頂天
- 自分本意　⇒　自己本位
- 一発即発　⇒　一触即発
- 意気高々　⇒　意気揚々
- 青色吐息　⇒　青息吐息
- 固定概念　⇒　固定観念
- 目に止まる　⇒　目に留まる
- 目を止める　⇒　目を留める
- 口が硬い　⇒　口が堅い
- 表情が固い　⇒　表情が硬い
- 無理が効かない　⇒　無理が利かない
- 睨みを効かせる　⇒　睨みを利かせる
- 癪に触る　⇒　癪に障る
- 見るに耐えない　⇒　見るに堪えない
- ずらい　⇒　づらい
- 思いもつかない　⇒　思いつかない
- 頭に留め置く　⇒　頭に入れておく
- 感心を買う　⇒　歓心を買う
- 恩を着て　⇒　恩に着て
- 脚光を集める　⇒　脚光を浴びる
- 足りえない　⇒　たりえない
- 案の上　⇒　案の定
- 合いの手を打つ　⇒　合いの手を入れる
- 相槌を入れる　⇒　相槌を打つ
- 耳障り良く　⇒　耳触り良く
- 無理なからぬ　⇒　無理からぬ
- 間髪いれず|間髪をおかず　⇒　間髪をいれず
- 食指をそそる|伸ばす　⇒　食指が動く
- 念頭に入れる|する　⇒　念頭に置いて
- 嫌気がする　⇒　嫌気が差す
- 精魂が尽きる　⇒　精根が尽きる
- 苦虫を噛んだような　⇒　苦虫を噛み潰したような
- 喝を入れる　⇒　活を入れる
- 一同に会する　⇒　一堂に会する

「目が留まる」については動詞の活用語尾の先頭一文字目がマッチングするよう設定しています。
本来ならばtokenにすべきところですが上手くいかず辞典データといたしました。

なお、誤用である根拠を示す出典を上げられなかった用例があります。
辞典による確認や「現代日本語書き言葉均衡コーパス」にて使用数の比較は行っておりますが、信頼性に欠けることは否めません。

何か不手際やご指摘あれば修正・取り下げいたします。
至らない点も多々あるかと思いますが何卒よろしくお願い申し上げます。