### PR TITLE
fix(dict): "ずらい" を 形態素解析ベースに変更

### DIFF
--- a/dict/prh.yml
+++ b/dict/prh.yml
@@ -172,9 +172,6 @@ rules:
   - expected: 口が堅い
     pattern: /口が[固硬]い/
     prh: 堅実さを意味する「堅い」を用いる
-  - expected: づらい
-    pattern: ずらい
-    prh: 動詞の連用形+辛い（つらい）
   - expected: 思い$1かない
     pattern: /思いも([付つ])かない/
     prh: 「思いつかない」で一つの動詞

--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -51,6 +51,54 @@ module.exports = [
                 "pos_detail_1": "自立"
             }
         ]
-
+    },
+    //
+    {
+        // https://azu.github.io/morpheme-match/?text=書きずらい
+        // ず + らい というToken
+        message: `動詞の連用形+辛い（つらい）の場合は、「ずらい」ではなく「づらい」が適切です。
+        
+参考: 
+- https://www.nhk.or.jp/bunken/summary/kotoba/uraomote/023.html
+- https://ameblo.jp/writer-yama/entry-10522384501.html`,
+        expected: "$1づらい",
+        tokens: [
+            {
+                "pos": "動詞",
+                "pos_detail_1": "自立",
+                "conjugated_form": "連用形",
+                "_capture": "$1"
+            },
+            {
+                "surface_form": "ず",
+            },
+            {
+                "surface_form": "らい",
+            }
+        ]
+    },
+    {
+        // https://azu.github.io/morpheme-match/?text=読みずらい
+        // ずら + い というToken
+        message: `動詞の連用形+辛い（つらい）の場合は、「ずらい」ではなく「づらい」が適切です。
+        
+参考: 
+- https://www.nhk.or.jp/bunken/summary/kotoba/uraomote/023.html
+- https://ameblo.jp/writer-yama/entry-10522384501.html`,
+        expected: "$1づらい",
+        tokens: [
+            {
+                "pos": "動詞",
+                "pos_detail_1": "自立",
+                "conjugated_form": "連用形",
+                "_capture": "$1"
+            },
+            {
+                "surface_form": "ずら",
+            },
+            {
+                "surface_form": "い",
+            }
+        ]
     }
 ];

--- a/test/no-confusing-adjust-and-apply-test.js
+++ b/test/no-confusing-adjust-and-apply-test.js
@@ -24,7 +24,8 @@ tester.run("textlint-rule-no-confusing-adjust-and-apply", rule, {
         "経営に失敗した企業に会社更生法を適用する",
         "厚生年金の適用",
         "規定を適用",
-        "法律を適用"
+        "法律を適用",
+        "読みづらい"
     ],
     invalid: [
         {
@@ -74,6 +75,32 @@ tester.run("textlint-rule-no-confusing-adjust-and-apply", rule, {
             errors: [
                 {
                     message: `"適用"の誤用である可能性があります。適応 => 適用`
+                }
+            ]
+        },
+        {
+            text: "この本は読みずらい",
+            output: "この本は読みづらい",
+            errors: [
+                {
+                    message: `動詞の連用形+辛い（つらい）の場合は、「ずらい」ではなく「づらい」が適切です。
+        
+参考: 
+- https://www.nhk.or.jp/bunken/summary/kotoba/uraomote/023.html
+- https://ameblo.jp/writer-yama/entry-10522384501.html`
+                }
+            ]
+        },
+        {
+            text: "この本は書きずらい",
+            output: "この本は書きづらい",
+            errors: [
+                {
+                    message: `動詞の連用形+辛い（つらい）の場合は、「ずらい」ではなく「づらい」が適切です。
+        
+参考: 
+- https://www.nhk.or.jp/bunken/summary/kotoba/uraomote/023.html
+- https://ameblo.jp/writer-yama/entry-10522384501.html`
                 }
             ]
         }


### PR DESCRIPTION
- https://azu.github.io/morpheme-match/?text=書きずらい
- https://azu.github.io/morpheme-match/?text=読みずらい

動詞の連用形 + ず + らい or 
動詞の連用形 + ずら + い

のパターンに対応しました。

[technological-book-corpus-ja](https://github.com/textlint-ja/technological-book-corpus-ja)のコーパスでチェックして見たところ、特に誤検知は起きませんでした。

```
# インストール
npm i -g . textlint technological-book-corpus-ja
# コーパスに対してルールを当ててチェックする
technological-book-corpus-ja | xargs textlint --rule textlint-rule-ja-no-abusage  -f pretty-error
```

/cc @hitoyo 