### PR TITLE
fix(dict):すべからくを辞書から削除

### DIFF
--- a/dict/prh.yml
+++ b/dict/prh.yml
@@ -96,9 +96,6 @@ rules:
   - expected: 押しも押されもせぬ
     patterns: 押しも押されぬ
     prh: https://web.archive.org/web/20150710180524/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=286
-  - expected: 全て
-    patterns: /すべからく(?!.*べ[しき])/
-    prh: https://web.archive.org/web/20150825091657/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=293
   - expected: 書き入れ
     patterns: 掻き入れ
     prh: http://japanknowledge.com/articles/blognihongo/entry.html?entryid=309

--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -100,20 +100,5 @@ module.exports = [
                 "surface_form": "い",
             }
         ]
-    },
-    {
-        // https://azu.github.io/morpheme-match/?text=すべからく
-        message: `意味を間違えやすい副詞です。すべからく = 進んですべき、（当然）そうあるべき
-        
-参考:
-- https://web.archive.org/web/20150825091657/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=293`,
-        tokens: [
-          {
-              "surface_form": "すべからく",
-              "pos": "副詞",
-              "pos_detail_1": "一般",
-              "basic_form": "すべからく"
-          }
-        ]
     }
 ];

--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -100,5 +100,20 @@ module.exports = [
                 "surface_form": "い",
             }
         ]
+    },
+    {
+        // https://azu.github.io/morpheme-match/?text=すべからく
+        message: `意味を間違えやすい副詞です。すべからく = 進んですべき、（当然）そうあるべき
+        
+参考:
+- https://web.archive.org/web/20150825091657/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=293`,
+        tokens: [
+          {
+              "surface_form": "すべからく",
+              "pos": "副詞",
+              "pos_detail_1": "一般",
+              "basic_form": "すべからく"
+          }
+        ]
     }
 ];

--- a/test/no-variable-test.js
+++ b/test/no-variable-test.js
@@ -20,4 +20,19 @@ tester.run("可変", rule, {
             ]
         }
     ]
+}),
+tester.run("すべからく", rule, {
+    invalid: [
+        {
+            text: "すべからく邁進しなければならない",
+            errors: [
+                {
+                    message: `意味を間違えやすい副詞です。すべからく = 進んですべき、（当然）そうあるべき
+        
+参考:
+- https://web.archive.org/web/20150825091657/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=293`,
+                }
+            ]
+        }
+    ]
 });

--- a/test/no-variable-test.js
+++ b/test/no-variable-test.js
@@ -20,19 +20,4 @@ tester.run("可変", rule, {
             ]
         }
     ]
-}),
-tester.run("すべからく", rule, {
-    invalid: [
-        {
-            text: "すべからく邁進しなければならない",
-            errors: [
-                {
-                    message: `意味を間違えやすい副詞です。すべからく = 進んですべき、（当然）そうあるべき
-        
-参考:
-- https://web.archive.org/web/20150825091657/http://japanknowledge.com/articles/blognihongo/entry.html?entryid=293`,
-                }
-            ]
-        }
-    ]
 });


### PR DESCRIPTION
"すべからく"が正規表現ベースの辞書で登録されていますが、
- "すべからく"の誤用は意味間違いによるもののため検知が難しい
- 正規表現でのマッチではfix先が必要になる

上記2点により正しい意味で使われていたときもfixコマンドで"全て"に修正されてしまう問題がありました。

これを解決するために"すべからく"を形態素解析ベースに変更しました。
"すべからく"を使用した際に注意を喚起するメッセージのみ表示します。


探り探りではありますがtokenを作成しました。
手元の環境ではテストに通りましたがなにか不手際がありましたらご教示ください。
よろしくお願い申し上げます。
