### PR TITLE
docs(readme): src/dictionary.ts へのリンクが切れている問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 など。詳細は辞書の定義を参照
 
 - [dict/prh.yml](dict/prh.yml)
-- [src/dictionary.js](src/dictionary.js)
+- [src/dictionary.ts](src/dictionary.ts)
 
 ## Install
 


### PR DESCRIPTION
#11 で `src/dictionary.js` が `src/dictionary.ts` に移動されたため、`[src/dictionary.js](src/dictionary.js)` が 404 となっていた。